### PR TITLE
Add kube events indexer

### DIFF
--- a/manifests/kube-events/deployment.yaml
+++ b/manifests/kube-events/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-events
+  namespace: logging
+  labels:
+    app: kube-events
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-events
+    spec:
+      containers:
+      - name: kube-events
+        image: giantswarm/tiny-tools
+        imagePullPolicy: Always
+        command:
+        - fish
+        - --command
+        - |
+          set kube_token (cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          curl --silent --fail --show-error --insecure --header "Authorization: Bearer $kube_token" \
+            --request GET https://kubernetes.default.svc/api/v1/watch/events \
+              | jq -c '.' | while read -l event
+            set -l index "kube-events-"(date --utc -I)
+            curl --request POST http://elasticsearch.logging.svc:9200/$index/event --data "$event"
+          end


### PR DESCRIPTION
This is just one loop on fishshell that take the event stream from the apiserver and sends it linewise to an Elasticsearch index. The index contains a date postfix for easy deletions of old indices.
This seems to crash from time to time. So there are some gaps. But helpful nonetheless for now.

It might be running at http://kibana-basic-auth.logging.l8.k8s.gigantic.io/goto/eba3b25bee1a061de1f7c66a89713619